### PR TITLE
Allow zooming and panning to be turned off

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+* Allow zooming & panning to be turned off
+
 # ggiraph 0.2.0
 
 ## Enhancement

--- a/R/ggiraph.R
+++ b/R/ggiraph.R
@@ -55,7 +55,7 @@ ggiraph <- function(code,
   stopifnot(tooltip_opacity > 0 && tooltip_opacity <= 1)
   stopifnot(tooltip_opacity > 0 && tooltip_opacity <= 1)
   stopifnot(is.numeric(zoom_max))
-  stopifnot( zoom_max > 1 )
+  stopifnot( zoom_max >= 1 )
 
 	ggiwid.options = getOption("ggiwid")
 	tmpdir = tempdir()

--- a/R/ggiraph.R
+++ b/R/ggiraph.R
@@ -24,6 +24,7 @@
 #' @param tooltip_offx tooltip x offset
 #' @param tooltip_offy tooltip y offset
 #' @param zoom_max maximum zoom factor
+#' @param zoompan should chart zoom and pan?
 #' @param ... arguments passed on to \code{\link[rvg]{dsvg}}
 #' @seealso \code{\link{geom_path_interactive}},
 #' \code{\link{geom_point_interactive}},
@@ -42,12 +43,15 @@ ggiraph <- function(code,
 	tooltip_offx = 10,
 	tooltip_offy = 0,
 	zoom_max = 6,
+	zoompan = T,
 	...) {
 
   if( missing( tooltip_extra_css ))
     tooltip_extra_css <- "padding:5px;background:black;color:white;border-radius:2px 2px 2px 2px;"
   if( missing( hover_css ))
     hover_css <- "fill:orange;"
+  if(zoompan==F & !missing(zoom_max))
+    warning("zoom_max has no effect when zoompan == F")
 
   stopifnot(is.numeric(tooltip_offx))
   stopifnot(is.numeric(tooltip_offy))
@@ -92,7 +96,8 @@ ggiraph <- function(code,
 	          tooltip_opacity = tooltip_opacity,
 	          tooltip_offx = tooltip_offx,
 	          tooltip_offy = tooltip_offy,
-	          zoom_max = zoom_max
+	          zoom_max = zoom_max,
+	          zoompan = zoompan
 	          )
 
 	# create widget

--- a/R/ggiraph.R
+++ b/R/ggiraph.R
@@ -55,7 +55,7 @@ ggiraph <- function(code,
   stopifnot(tooltip_opacity > 0 && tooltip_opacity <= 1)
   stopifnot(tooltip_opacity > 0 && tooltip_opacity <= 1)
   stopifnot(is.numeric(zoom_max))
-  stopifnot( zoom_max >= 1 )
+  stopifnot( zoom_max > 1 )
 
 	ggiwid.options = getOption("ggiwid")
 	tmpdir = tempdir()

--- a/inst/htmlwidgets/ggiraph.js
+++ b/inst/htmlwidgets/ggiraph.js
@@ -63,10 +63,12 @@ HTMLWidgets.widget({
                     .duration(500)
                     .style("opacity", 0);
             });
-          var zoom_l = d3.behavior.zoom().scaleExtent([1, x.zoom_max]).on("zoom", zoom_h);
-          zoom_l(d3.select('#svg_' + x.canvas_id + ' g'));
-          d3.select('#svg_' + x.canvas_id).attr("width", width).attr("height", height);
-          force.size([width, height]).resume();
+          if(x.zoompan===true) {
+            var zoom_l = d3.behavior.zoom().scaleExtent([1, x.zoom_max]).on("zoom", zoom_h);
+            zoom_l(d3.select('#svg_' + x.canvas_id + ' g'));
+            d3.select('#svg_' + x.canvas_id).attr("width", width).attr("height", height);
+            force.size([width, height]).resume();
+          }
       },
 
       resize: function(width, height) {

--- a/man/ggiraph.Rd
+++ b/man/ggiraph.Rd
@@ -6,7 +6,7 @@
 \usage{
 ggiraph(code, pointsize = 12, width = 6, height = 6, tooltip_extra_css,
   hover_css, tooltip_opacity = 0.9, tooltip_offx = 10, tooltip_offy = 0,
-  zoom_max = 6, ...)
+  zoom_max = 6, zoompan = T, ...)
 }
 \arguments{
 \item{code}{Plotting code to execute}
@@ -29,6 +29,8 @@ used to customize tooltip area.}
 \item{tooltip_offy}{tooltip y offset}
 
 \item{zoom_max}{maximum zoom factor}
+
+\item{zoompan}{should chart zoom and pan?}
 
 \item{...}{arguments passed on to \code{\link[rvg]{dsvg}}}
 }


### PR DESCRIPTION
I found the zooming and panning unnecessary for many use cases (esp. because it steals scrolling focus when the plot is embedded in a longer page), so I added a param to allow it to be turned off. It might be useful to allow zooming and panning to be controlled separately but I didn’t want to fiddle with the javascript too much at this point.