### PR TITLE
Parameterized `dep_dir`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+# ggiraph 0.4.2
+
+## Changes
+
+* ggiraph has a new argument `dep_dir` that controls the location of the output files.
+
+
 # ggiraph 0.4.1
 
 ## Changes

--- a/R/ggiraph.R
+++ b/R/ggiraph.R
@@ -52,6 +52,8 @@
 #' @param use_widget_size use htmlwidget width and height
 #' @param flexdashboard should be TRUE when used within a flexdashboard to
 #' ensure svg will fit in boxes.
+#' @param dep_dir the path where the output files are stored. If \code{NULL},
+#'  the current path for temporary files is used. 
 #' @param ... arguments passed on to \code{\link[rvg]{dsvg}}
 #' @examples
 #' # ggiraph simple example -------
@@ -70,6 +72,7 @@ ggiraph <- function(code, ggobj = NULL,
 	use_widget_size = FALSE,
 	selection_type = "multiple",
 	selected_css, flexdashboard = FALSE,
+	dep_dir = NULL,
 	...) {
 
   if( missing( tooltip_extra_css ))
@@ -134,8 +137,13 @@ ggiraph <- function(code, ggobj = NULL,
 
   id <- gsub("-", "", paste0("uid", UUIDgenerate() ))
 
-  dep_dir <- tempfile()
-  dir.create(dep_dir)
+  if ( is.null(dep_dir) ) {
+    dep_dir <- tempfile()
+    dir.create(dep_dir)
+  } else {
+    if ( !dir.exists(dep_dir) )
+      stop(dep_dir, " does not exist.", call. = FALSE)
+  }
 
   init_prop_name <- paste0("init_prop_", id)
   array_selected_name <- paste0("array_selected_", id)

--- a/man/ggiraph.Rd
+++ b/man/ggiraph.Rd
@@ -8,7 +8,7 @@ ggiraph(code, ggobj = NULL, pointsize = 12, width = 0.8, width_svg = 6,
   height_svg = 6, tooltip_extra_css, hover_css, tooltip_opacity = 0.9,
   tooltip_offx = 10, tooltip_offy = 0, tooltip_zindex = 999,
   zoom_max = 1, use_widget_size = FALSE, selection_type = "multiple",
-  selected_css, flexdashboard = FALSE, ...)
+  selected_css, flexdashboard = FALSE, dep_dir = NULL, ...)
 }
 \arguments{
 \item{code}{Plotting code to execute}
@@ -46,6 +46,9 @@ when widget is in a Shiny application.}
 
 \item{flexdashboard}{should be TRUE when used within a flexdashboard to
 ensure svg will fit in boxes.}
+
+\item{dep_dir}{the path where the output files are stored. If \code{NULL},
+the current path for temporary files is used.}
 
 \item{...}{arguments passed on to \code{\link[rvg]{dsvg}}}
 }


### PR DESCRIPTION
This PR is to help `ggiraph` work better with `bookdown`. see rstudio/bookdown#15 and [this post](https://stackoverflow.com/questions/46488976/ggiraph-htmlwidgets-with-bookdown-and-new-session-yes). 

The path for the output files is now an argument. I tested it on [topepo/bookdown-demo](https://github.com/topepo/bookdown-demo). There's not `tests` directory but I can confirm that it appropriate errors when the expected directory does not exist: 

```r
> mtcars$car <- rownames(mtcars)
> 
> p2 <- ggplot(mtcars, aes(x = disp, y = mpg)) + 
+   geom_point_interactive(aes(tooltip = car))
> ggiraph(code = print(p2), dep_dir = "~/tmp/ggiraph_test")
Error: ~/tmp/ggiraph_test does not exist.
```
