### PR TITLE
geom_hline_interactive and geom_vline_interactive

### DIFF
--- a/R/geom_hline_interactive.R
+++ b/R/geom_hline_interactive.R
@@ -1,0 +1,48 @@
+# ==== geom_hline_interactive ====
+
+geom_hline_interactive <- function(mapping = NULL, data = NULL,
+                                   ...,
+                                   yintercept,
+                                   na.rm = FALSE,
+                                   show.legend = NA) {
+
+  # Act like an annotation
+  if (!missing(yintercept)) {
+    data <- data.frame(yintercept = yintercept)
+    mapping <- aes(yintercept = yintercept)
+    show.legend <- FALSE
+  }
+
+  layer(
+    data = data,
+    mapping = mapping,
+    stat = StatIdentity,
+    geom = GeomInteractiveHline,
+    position = PositionIdentity,
+    show.legend = show.legend,
+    inherit.aes = FALSE,
+    params = list(
+      na.rm = na.rm,
+      ...
+    )
+  )
+}
+
+
+GeomInteractiveHline <- ggproto("GeomHline", Geom,
+                                draw_panel = function(data, panel_scales, coord) {
+                                  ranges <- coord$range(panel_scales)
+
+                                  data$x    <- ranges$x[1]
+                                  data$xend <- ranges$x[2]
+                                  data$y    <- data$yintercept
+                                  data$yend <- data$yintercept
+
+                                  GeomInteractiveSegment$draw_panel(unique(data), panel_scales, coord)
+                                },
+
+                                default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = NA),
+                                required_aes = "yintercept",
+
+                                draw_key = draw_key_path
+)

--- a/R/geom_hline_interactive.R
+++ b/R/geom_hline_interactive.R
@@ -1,5 +1,16 @@
-# ==== geom_hline_interactive ====
-
+#' @title Horizontal interactive reference line
+#'
+#' @description
+#' The geometry is based on \code{\link[ggplot2]{geom_hline}}.
+#' See the documentation for those functions for more details.
+#'
+#' @seealso \code{\link{ggiraph}}
+#' @inheritParams geom_point_interactive
+#' @param yintercept controls the position of the line
+#' @examples
+#' # add interactive reference lines to a ggplot -------
+#' @example examples/geom_hline_interactive.R
+#' @export
 geom_hline_interactive <- function(mapping = NULL, data = NULL,
                                    ...,
                                    yintercept,

--- a/R/geom_vline_interactive.R
+++ b/R/geom_vline_interactive.R
@@ -1,6 +1,16 @@
-# ==== geom_vline_interactive ====
-
-
+#' @title Vertical interactive reference line
+#'
+#' @description
+#' The geometry is based on \code{\link[ggplot2]{geom_vline}}.
+#' See the documentation for those functions for more details.
+#'
+#' @seealso \code{\link{ggiraph}}
+#' @inheritParams geom_point_interactive
+#' @param xintercept controls the position of the line
+#' @examples
+#' # add interactive reference lines to a ggplot -------
+#' @example examples/geom_vline_interactive.R
+#' @export
 geom_vline_interactive <- function(mapping = NULL, data = NULL,
                                    ...,
                                    xintercept,

--- a/R/geom_vline_interactive.R
+++ b/R/geom_vline_interactive.R
@@ -1,0 +1,49 @@
+# ==== geom_vline_interactive ====
+
+
+geom_vline_interactive <- function(mapping = NULL, data = NULL,
+                                   ...,
+                                   xintercept,
+                                   na.rm = FALSE,
+                                   show.legend = NA) {
+
+  # Act like an annotation
+  if (!missing(xintercept)) {
+    data <- data.frame(xintercept = xintercept)
+    mapping <- aes(xintercept = xintercept)
+    show.legend <- FALSE
+  }
+
+  layer(
+    data = data,
+    mapping = mapping,
+    stat = StatIdentity,
+    geom = GeomInteractiveVline,
+    position = PositionIdentity,
+    show.legend = show.legend,
+    inherit.aes = FALSE,
+    params = list(
+      na.rm = na.rm,
+      ...
+    )
+  )
+}
+
+
+GeomInteractiveVline <- ggproto("GeomVline", Geom,
+                                draw_panel = function(data, panel_scales, coord) {
+                                  ranges <- coord$range(panel_scales)
+
+                                  data$x    <- data$xintercept
+                                  data$xend <- data$xintercept
+                                  data$y    <- ranges$y[1]
+                                  data$yend <- ranges$y[2]
+
+                                  GeomInteractiveSegment$draw_panel(unique(data), panel_scales, coord)
+                                },
+
+                                default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = NA),
+                                required_aes = "xintercept",
+
+                                draw_key = draw_key_vline
+)

--- a/examples/geom_hline_iteractive.R
+++ b/examples/geom_hline_iteractive.R
@@ -1,0 +1,24 @@
+library(ggplot2)
+
+
+g1 <- ggplot(economics, aes(x = date, y = unemploy)) + geom_point() + geom_line()
+
+gg_hline1 <- g1 + geom_hline_interactive(aes(yintercept = mean(unemploy), tooltip = round(mean(unemploy), 2)))
+
+
+dataset = data.frame(x=c(1,2,5,6,8),
+                     y=c(3,6,2,8,7),
+                     vx=c(1,1.5,0.8,0.5,1.3),
+                     vy=c(0.2,1.3,1.7,0.8,1.4),
+                     year = c(2014, 2015, 2016, 2017, 2018))
+
+dataset$clickjs = rep(paste0("alert(\"",mean(dataset$y), "\")"), 5)
+
+
+g2 <- ggplot(dataset, aes(x = year, y = y)) + geom_point() + geom_line()
+
+gg_hline2 <- g2 + geom_hline_interactive(aes(yintercept = mean(y), tooltip = round(mean(y), 2), data_id = y, onclick = clickjs))
+
+
+ggiraph(code = print(gg_hline1))
+ggiraph(code = print(gg_hline2), hover_css = "cursor:pointer;fill:orange;stroke:orange;")

--- a/examples/geom_vline_interactive.R
+++ b/examples/geom_vline_interactive.R
@@ -1,0 +1,18 @@
+library(ggplot2)
+
+
+g1 <- ggplot(diamonds, aes(carat)) +
+      geom_histogram()
+
+gg_vline1 <- g1 + geom_vline_interactive(aes(xintercept = mean(carat), tooltip = round(mean(carat),2), data_id = carat))
+
+dataset <- data.frame(x = rnorm(100))
+
+dataset$clickjs = rep(paste0("alert(\"",round(mean(dataset$x), 2), "\")"), 100)
+
+g2 <- ggplot(dataset, aes(x)) +
+      geom_density(fill = "#000000", alpha = 0.7)
+gg_vline2 <- g2 + geom_vline_interactive(aes(xintercept = mean(x), tooltip = round(mean(x), 2), data_id = x, onclick = clickjs), color = "white")
+
+ggiraph(code = print(gg_vline1))
+ggiraph(code = print(gg_vline2), hover_css = "cursor:pointer;fill:orange;stroke:orange;")


### PR DESCRIPTION
Closes #97

`geom_hline_interactive` and `geom_vline_interactive` are interactive reference lines based on their counterparts `geom_hline` and `geom_vline` in `ggplot2`

* Added geom_hline_interactive.R and geom_vline_interactive.R to R directory
* Added geom_hline_interactive.R and geom_vline_interactive.R to examples directory