### PR TITLE
[fix] Set svg max width/height from its viewbox

### DIFF
--- a/inst/htmlwidgets/girafe.js
+++ b/inst/htmlwidgets/girafe.js
@@ -52,7 +52,14 @@ HTMLWidgets.widget({
         } else if( HTMLWidgets.shinyMode ){
           ggobj.autoScale("100%");
           ggobj.IEFixResize(1, 1/x.ratio);
-          ggobj.setSizeLimits(width+'px', 0, height+'px', 0);
+          var maxWidth = width;
+          var maxHeight = height;
+          try {
+            const box = d3.select("#" + ggobj.svgid).property("viewBox").baseVal;
+            maxWidth = box.width;
+            maxHeight = box.height;
+          } catch (e) {}
+          ggobj.setSizeLimits(maxWidth+'px', 0, maxHeight+'px', 0);
           ggobj.removeContainerLimits();
         } else {
           ggobj.autoScale(Math.round(x.settings.sizing.width * 100) + "%");


### PR DESCRIPTION
This is a fix for #127.
Sometimes the height that receives the htmlwidget is 0.
And when "rescale" option is true, this causes the maxHeight of the svg to be set to 0, so it will not be visible.
This patch sets the maxWidth & maxHeight attributes from the svg "viewbox" property and so they'll never be 0.