### PR TITLE
Windows: update libs + ucrt support

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,0 +1,2 @@
+CRT=-ucrt
+include Makevars.win

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,9 +1,9 @@
-RWINLIB = ../windows/baselibs-3.5.0
+RWINLIB = ../windows/harfbuzz-2.7.4
 
 PKG_CPPFLAGS = -I${RWINLIB}/include \
 	-DSTRICT_R_HEADERS
 
-PKG_LIBS = -L${RWINLIB}/lib${R_ARCH} -lpng -lz
+PKG_LIBS = -L${RWINLIB}/lib${R_ARCH}${CRT} -lpng -lz
 
 all: clean winlibs
 

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,7 +1,7 @@
-BASELIB <- "3.5.0"
-if(!file.exists(sprintf("../windows/baselibs-%s/include/png.h", BASELIB))){
+VERSION <- "2.7.4"
+if(!file.exists(sprintf("../windows/harfbuzz-%s/include/png.h", VERSION))){
   if(getRversion() < "3.3.0") setInternet2()
-  download.file(sprintf("https://github.com/rwinlib/baselibs/archive/v%s.zip", BASELIB), "lib.zip", quiet = TRUE)
+  download.file(sprintf("https://github.com/rwinlib/harfbuzz/archive/v%s.zip", VERSION), "lib.zip", quiet = TRUE)
   dir.create("../windows", showWarnings = FALSE)
   unzip("lib.zip", exdir = "../windows")
   unlink("lib.zip")


### PR DESCRIPTION
This is needed for the new experimental ucrt toolchains.