### PR TITLE
Make girafe_options() more robust to changes in htmlwidgets::sizingPolicy()

### DIFF
--- a/R/girafe_options.R
+++ b/R/girafe_options.R
@@ -618,10 +618,7 @@ merge_options <- function(options, args){
 
 merge_sizing_policy <- function(policy, args) {
   for (arg in args) {
-    if (is.list(arg) && all(names(arg) %in% c(
-      "defaultWidth", "defaultHeight", "padding",
-      "viewer", "browser", "knitr"
-    ))) {
+    if (is.list(arg) && all(names(arg) %in% names(htmlwidgets::sizingPolicy()))) {
       policy <- arg
     }
   }


### PR DESCRIPTION
Closes #244

It'd be much appreciated if this patch fix could be submitted to CRAN asap to accommodate the htmlwidgets 1.6 release, which I plan on submitting in the next 1-2 weeks