### PR TITLE
Use png from the system via pkg-config.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,2 +1,8 @@
-CRT=-ucrt
-include Makevars.win
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  PKG_LIBS = -lpng -lz
+else
+  PKG_CPPFLAGS = $(shell pkg-config --cflags libpng)
+  PKG_LIBS = $(shell pkg-config --libs libpng)
+endif
+
+PKG_CPPFLAGS += -DSTRICT_R_HEADERS


### PR DESCRIPTION
This patch switches to using png from the system, when available via pkg-config or otherwise using hard-coded library dependencies. It makes the package work with png from Rtools42-45. Behavior with previous versions of R is not affected, as this uses the .ucrt version of Makevars.

Using libraries from the system/Rtools when available is required by the CRAN repository policy. Also, it silences a warning (now on CRAN results) about using non-allowed external symbols.
