### PR TITLE
Compatibility with ggplot2 4.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ URL: https://davidgohel.github.io/ggiraph/
 BugReports: https://github.com/davidgohel/ggiraph/issues
 Imports:
     cli,
-    ggplot2 (>= 3.5.1),
+    ggplot2 (>= 3.5.2),
     grid,
     htmltools,
     htmlwidgets (>= 1.5),

--- a/R/geom_bar_interactive.R
+++ b/R/geom_bar_interactive.R
@@ -27,8 +27,7 @@ GeomInteractiveBar <- ggproto(
   default_aes = add_default_interactive_aes(GeomBar),
   parameters = interactive_geom_parameters,
   draw_key = interactive_geom_draw_key,
-  draw_panel = function(self, data, panel_params, coord,
-                        width = NULL, flipped_aes = FALSE,
+  draw_panel = function(self, data, panel_params, coord, ...,
                         .ipar = IPAR_NAMES) {
     GeomInteractiveRect$draw_panel(data, panel_params, coord, .ipar = .ipar)
   }

--- a/R/geom_path_interactive.R
+++ b/R/geom_path_interactive.R
@@ -129,7 +129,7 @@ GeomInteractiveStep <-
     default_aes = add_default_interactive_aes(GeomStep),
     parameters = interactive_geom_parameters,
     draw_key = interactive_geom_draw_key,
-    draw_panel = function(data, panel_params, coord, direction = "hv", .ipar = IPAR_NAMES) {
+    draw_panel = function(data, panel_params, coord, direction = "hv", .ipar = IPAR_NAMES, ...) {
       ldata <- split(data, data$group)
       ldata <- lapply(ldata, stairstep, direction = direction)
       data <- do.call(rbind, ldata)

--- a/inst/tinytest/setup.R
+++ b/inst/tinytest/setup.R
@@ -74,7 +74,7 @@ test_geom_layer <- expression({
   }
   # has that class default interactive params?
   geom_class_ipar <- unclass(ggiraph:::get_interactive_attrs(result$geom$default_aes))
-  expect_equal(geom_class_ipar, ggiraph:::IPAR_DEFAULTS, info = name)
+  expect_equal(geom_class_ipar, ggiraph:::IPAR_DEFAULTS, info = name, check.attributes = FALSE)
   # has the layer the passed interactive params in aes?
   geom_aes_ipar <- unclass(ggiraph:::get_interactive_attrs(result$mapping))
   expect_equal(geom_aes_ipar, unclass(mapping), info = name)
@@ -112,7 +112,7 @@ test_annot_layer <- expression({
   expect_false(is.null(nse[[cl]]), info = cl)
   # has that class default interactive params?
   geom_class_ipar <- unclass(ggiraph:::get_interactive_attrs(result$geom$default_aes))
-  expect_equal(geom_class_ipar, ggiraph:::IPAR_DEFAULTS, info = name)
+  expect_equal(geom_class_ipar, ggiraph:::IPAR_DEFAULTS, info = name, check.attributes = FALSE)
   # has the layer the passed interactive params in aes_params?
   geom_aes_par_ipar <- unclass(ggiraph:::get_interactive_attrs(result$aes_params))
   expect_equal(geom_aes_par_ipar, mapping, info = name)

--- a/inst/tinytest/test-utils.R
+++ b/inst/tinytest/test-utils.R
@@ -42,16 +42,8 @@ library(ggplot2)
     unclass(ggiraph:::add_default_interactive_aes(GeomPoint,
       defaults = list(tooltip = NULL, foo = "bar")
     )),
-    list(
-      shape = 19,
-      colour = "black",
-      size = 1.5,
-      fill = NA,
-      alpha = NA,
-      stroke = 0.5,
-      tooltip = NULL,
-      foo = "bar"
-    )
+    c(unclass(GeomPoint$default_aes), aes(tooltip = NULL, foo = "bar")),
+    check.attributes = FALSE
   )
 }
 
@@ -95,7 +87,7 @@ library(ggplot2)
   layer <- geom_point_interactive(aes(tooltip = "tooltip"))
   geom <- layer$geom
   data <- as.data.frame(c(
-    ggiraph:::compact(unclass(geom$default_aes)),
+    ggiraph:::compact(get_geom_defaults(geom)),
     ggiraph:::compact(unclass(layer$mapping))
   ))
   gr <- ggiraph:::interactive_geom_draw_key(geom, data = data, params = geom$parameters(), size = 3)


### PR DESCRIPTION
Hi there,

We've been preparing for a new major release of ggplot2 and ggiraph showed up on the reverse dependency checks. 
This PR contains the changes that would maintain compatibility with ggiraph and ggplot2 for the new version.
The main change in ggplot2 that affects ggiraph is that the `Geom$default_aes` field contains more unevaluated expressions than before.
We hope to send the release to CRAN sometime soon.

Best wishes,
Teun