### PR TITLE
proposed fix for #331

### DIFF
--- a/R/geom_col_interactive.R
+++ b/R/geom_col_interactive.R
@@ -19,10 +19,19 @@ GeomInteractiveCol <- ggproto(
     data,
     panel_params,
     coord,
+    lineend = "butt",
+    linejoin = "mitre",
     width = NULL,
     flipped_aes = FALSE,
     .ipar = IPAR_NAMES
   ) {
-    GeomInteractiveRect$draw_panel(data, panel_params, coord, .ipar = .ipar)
+    GeomInteractiveRect$draw_panel(
+      data,
+      panel_params,
+      coord,
+      lineend = lineend,
+      linejoin = linejoin,
+      .ipar = .ipar
+    )
   }
 )


### PR DESCRIPTION
In limited testing, it appears that adding `lineend` and `linejoin` as arguments to GeomColnteractive's `draw_panel()` solves the problem in #331.